### PR TITLE
Fix AES-GCM decryption of block spanning frames

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -492,6 +492,7 @@ _libssh2_cipher_crypt(_libssh2_cipher_ctx * ctx,
     (void) algo;
 
     assert(blocksize <= sizeof(buf));
+    assert(cryptlen >= 0);
 
     /* First block */
     if(IS_FIRST(firstlast)) {

--- a/src/transport.c
+++ b/src/transport.c
@@ -150,13 +150,14 @@ decrypt(LIBSSH2_SESSION * session, unsigned char *source,
         int decryptlen = MIN(blocksize, len);
         /* The first block is special (since it needs to be decoded to get the
            length of the remainder of the block) and takes priority. When the
-           length finally gets to the last blocksize bytes, it's the end. */
+           length finally gets to the last blocksize bytes, and there's no
+           more data to come, it's the end. */
         int lowerfirstlast = IS_FIRST(firstlast) ? FIRST_BLOCK :
-            ((len <= blocksize) ? LAST_BLOCK : MIDDLE_BLOCK);
+            ((len <= blocksize) ? firstlast : MIDDLE_BLOCK);
         /* If the last block would be less than a whole blocksize, combine it
            with the previous block to make it larger. This ensures that the
            whole MAC is included in a single decrypt call. */
-        if(CRYPT_FLAG_L(session, PKTLEN_AAD) && !IS_FIRST(firstlast)
+        if(CRYPT_FLAG_L(session, PKTLEN_AAD) && IS_LAST(firstlast)
             && (len < blocksize*2)) {
             decryptlen = len;
             lowerfirstlast = LAST_BLOCK;


### PR DESCRIPTION
The authentication tag was erroneously checked too soon in this case.